### PR TITLE
Fix: Missing whitespace separation in iCal summary for exam events

### DIFF
--- a/plan/ical/views.py
+++ b/plan/ical/views.py
@@ -137,7 +137,7 @@ def add_exams(exams, cal, hostname):
             desc = _('Exam') + u' (%s) - %s (%s)' % (e.type.code, e.course.name,
                     e.course.code)
         else:
-            summary = _('Exam') + e.alias or e.course.code
+            summary = _('Exam') + u' %s' % (e.alias or e.course.code)
             desc = _('Exam') + u' %s (%s)' % (e.course.name, e.course.code)
 
         vevent.add('summary').value = summary


### PR DESCRIPTION
The summary of an exam event is missing a whitespace.

<img width="612" alt="skjermbilde 2017-01-12 kl 12 57 15" src="https://cloud.githubusercontent.com/assets/147197/21889367/e24fd9ec-d8c8-11e6-9030-dba0f7c8ff9b.png">

Would have liked to add tests, but following the readme.rst did not get me up and running.